### PR TITLE
Use popup logo icon in header

### DIFF
--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -309,7 +309,7 @@
 </head>
 <body>
   <div class="header">
-    <div class="logo-mark" aria-hidden="true"></div>
+    <img src="../icons/icon128.png" alt="Logo" class="logo-mark" aria-hidden="true" />
     <h1>GitHub Country Filter</h1>
   </div>
 


### PR DESCRIPTION
## Summary
- replace the popup header mark with the extension icon image
- keep the popup behavior unchanged
- align the header branding with the actual extension asset

## Testing
- not run
