### PR TITLE
Add country reason hover card

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -13,6 +13,7 @@ async function getFromCache(username) {
   const entry = cache[username];
   if (!entry) return null;
   if (Date.now() - entry.timestamp > CACHE_TTL_MS) return null;
+  if (!Array.isArray(entry.result?.reasons)) return null;
   return entry.result;
 }
 

--- a/extension/content.css
+++ b/extension/content.css
@@ -1,4 +1,11 @@
 .ghcf-badge {
+  --ghcf-popover-bg: var(--overlay-bgColor, var(--bgColor-default, #ffffff));
+  --ghcf-popover-bg-alt: var(--bgColor-muted, #f6f8fa);
+  --ghcf-popover-border: var(--borderColor-default, #d1d9e0);
+  --ghcf-popover-text: var(--fgColor-default, #1f2328);
+  --ghcf-popover-title: var(--fgColor-muted, #59636e);
+  --ghcf-popover-accent: var(--fgColor-accent, #0969da);
+  position: relative;
   display: inline-flex;
   align-items: center;
   gap: 4px;
@@ -19,6 +26,29 @@
   text-decoration: none !important;
   box-sizing: border-box;
   box-shadow: var(--button-default-shadow-resting, 0 1px 0 rgba(31, 35, 40, 0.04));
+  transform-origin: left center;
+  transition:
+    transform 0.16s ease,
+    box-shadow 0.16s ease,
+    border-color 0.16s ease,
+    background-color 0.16s ease;
+  overflow: visible;
+  z-index: 0;
+}
+
+.ghcf-badge--interactive:hover,
+.ghcf-badge--interactive:focus-visible {
+  transform: scale(1.06);
+  border-color: var(--borderColor-accent-emphasis, var(--borderColor-default, #d1d9e0));
+  box-shadow:
+    0 10px 22px rgba(31, 35, 40, 0.12),
+    0 1px 0 rgba(31, 35, 40, 0.04);
+  z-index: 20;
+}
+
+.ghcf-badge--interactive:focus-visible {
+  outline: 2px solid var(--focus-outlineColor, #0969da);
+  outline-offset: 2px;
 }
 
 .ghcf-flag {
@@ -57,6 +87,84 @@
 
 .ghcf-meta {
   font-weight: 500;
+}
+
+.ghcf-reason {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  display: grid;
+  gap: 6px;
+  min-width: 220px;
+  max-width: 320px;
+  padding: 10px 12px;
+  border: 1px solid var(--ghcf-popover-border);
+  border-radius: 12px;
+  background:
+    linear-gradient(180deg, var(--ghcf-popover-bg), var(--ghcf-popover-bg-alt));
+  color: var(--ghcf-popover-text);
+  box-shadow:
+    0 16px 40px rgba(31, 35, 40, 0.14),
+    0 1px 0 rgba(31, 35, 40, 0.04);
+  white-space: normal;
+  line-height: 1.45;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-4px) scale(0.98);
+  transform-origin: top left;
+  transition:
+    opacity 0.16s ease,
+    transform 0.16s ease,
+    visibility 0.16s ease;
+  pointer-events: auto;
+}
+
+.ghcf-reason::before {
+  content: '';
+  position: absolute;
+  top: -6px;
+  left: 16px;
+  width: 10px;
+  height: 10px;
+  border-top: 1px solid var(--ghcf-popover-border);
+  border-left: 1px solid var(--ghcf-popover-border);
+  background: var(--ghcf-popover-bg);
+  transform: rotate(45deg);
+}
+
+.ghcf-badge--interactive:hover .ghcf-reason,
+.ghcf-badge--interactive:focus-visible .ghcf-reason {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0) scale(1);
+}
+
+.ghcf-reason-title {
+  display: block;
+  color: var(--ghcf-popover-title);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.ghcf-reason-item {
+  display: block;
+  position: relative;
+  padding-left: 12px;
+  font-size: 12px;
+  color: var(--ghcf-popover-text);
+}
+
+.ghcf-reason-item::before {
+  content: '';
+  position: absolute;
+  top: 0.55em;
+  left: 0;
+  width: 5px;
+  height: 5px;
+  border-radius: 999px;
+  background: var(--ghcf-popover-accent);
 }
 
 .ghcf-badge--certain .ghcf-code {

--- a/extension/content.js
+++ b/extension/content.js
@@ -177,11 +177,13 @@ async function processItems() {
       loadingBadge.remove();
       if (!response || response.error) return;
 
-      const { country, confidence } = response;
+      const { country, confidence, reasons = [] } = response;
       const displayName = COUNTRY_DISPLAY[country] || country;
-      const badge = renderBadge(country, confidence, displayName);
+      const badge = renderBadge(country, confidence, displayName, reasons);
       target.insertAdjacentElement('afterend', badge);
-      console.log(`[GHCF] ${owner} → ${country} (${Math.round(confidence * 100)}%)`);
+      const reasonSummary = formatReasonSummary(reasons);
+      const logSuffix = reasonSummary ? ` | reasons: ${reasonSummary}` : '';
+      console.log(`[GHCF] ${owner} → ${country} (${Math.round(confidence * 100)}%)${logSuffix}`);
 
 
       // 필터 적용
@@ -271,16 +273,60 @@ function createFlagFallback(country) {
   return fallback;
 }
 
-function renderBadge(country, confidence, displayName) {
+function getReasonItems(reasons) {
+  if (!Array.isArray(reasons)) return [];
+  return reasons.filter(reason => reason && typeof reason.text === 'string' && reason.text.trim());
+}
+
+function formatReasonSummary(reasons) {
+  return getReasonItems(reasons)
+    .slice(0, 3)
+    .map(reason => reason.text)
+    .join(' | ');
+}
+
+function createReasonPanel(reasons) {
+  const items = getReasonItems(reasons).slice(0, 3);
+  if (items.length === 0) return null;
+
+  const panel = document.createElement('span');
+  panel.className = 'ghcf-reason';
+  panel.setAttribute('aria-hidden', 'true');
+
+  const title = document.createElement('span');
+  title.className = 'ghcf-reason-title';
+  title.textContent = 'Why this country';
+  panel.appendChild(title);
+
+  for (const reason of items) {
+    const item = document.createElement('span');
+    item.className = 'ghcf-reason-item';
+    item.textContent = reason.text;
+    panel.appendChild(item);
+  }
+
+  return panel;
+}
+
+function renderBadge(country, confidence, displayName, reasons = []) {
   const badge = document.createElement('span');
   badge.className = 'ghcf-badge';
   badge.setAttribute('data-ghcf-country', country);
+  const reasonSummary = formatReasonSummary(reasons);
+  const reasonPanel = createReasonPanel(reasons);
 
   if (country === 'Unknown') {
     badge.classList.add('ghcf-badge--unknown');
-    badge.title = 'Country could not be detected';
+    badge.title = reasonSummary
+      ? `Country could not be detected | Reasons: ${reasonSummary}`
+      : 'Country could not be detected';
     badge.appendChild(createFlagFallback(country));
     appendBadgePart(badge, 'ghcf-label', 'Unknown');
+    if (reasonPanel) {
+      badge.classList.add('ghcf-badge--interactive');
+      badge.tabIndex = 0;
+      badge.appendChild(reasonPanel);
+    }
     return badge;
   }
 
@@ -292,12 +338,22 @@ function renderBadge(country, confidence, displayName) {
     ? `Country: ${displayName} (${confidencePercent}% confidence)`
     : `Country: ${displayName} (estimated, ${confidencePercent}% confidence)`;
 
+  if (reasonSummary) {
+    badge.title += ` | Reasons: ${reasonSummary}`;
+  }
+
   appendFlagIcon(badge, country);
   appendBadgePart(badge, 'ghcf-label', displayName);
   appendBadgePart(badge, 'ghcf-code', country, true);
 
   if (!isCertain) {
     appendBadgePart(badge, 'ghcf-meta', 'Est.', true);
+  }
+
+  if (reasonPanel) {
+    badge.classList.add('ghcf-badge--interactive');
+    badge.tabIndex = 0;
+    badge.appendChild(reasonPanel);
   }
 
   return badge;

--- a/extension/country_detector.js
+++ b/extension/country_detector.js
@@ -328,6 +328,14 @@ export const COUNTRY_DISPLAY = {
 // 감지 함수들
 // ─────────────────────────────────────────────
 
+function createSignal(country, confidence, source, reason) {
+  return { country, confidence, source, reason };
+}
+
+function quoteValue(value) {
+  return `"${String(value).trim()}"`;
+}
+
 function parseLocation(location) {
   if (!location) return [];
 
@@ -337,16 +345,29 @@ function parseLocation(location) {
   const JUNK = ['earth', 'remote', 'internet', 'worldwide', 'global', 'everywhere', 'world', 'online', 'universe', 'home'];
   if (JUNK.some(j => normalized === j)) return [];
 
-  const found = new Map(); // country → highest confidence
+  const found = new Map(); // country -> strongest location signal
+
+  const remember = (country, confidence, reason) => {
+    const prev = found.get(country);
+    if (!prev || confidence > prev.confidence) {
+      found.set(country, { confidence, reason });
+    }
+  };
 
   const tryMatch = (text, confidence) => {
     if (COUNTRY_MAP[text]) {
-      const prev = found.get(COUNTRY_MAP[text]) || 0;
-      if (confidence > prev) found.set(COUNTRY_MAP[text], confidence);
+      remember(
+        COUNTRY_MAP[text],
+        confidence,
+        `location matches country keyword ${quoteValue(text)}`
+      );
     }
     if (CITY_MAP[text]) {
-      const prev = found.get(CITY_MAP[text]) || 0;
-      if (confidence > prev) found.set(CITY_MAP[text], confidence - 0.05);
+      remember(
+        CITY_MAP[text],
+        confidence - 0.05,
+        `location mentions city keyword ${quoteValue(text)}`
+      );
     }
   };
 
@@ -362,18 +383,18 @@ function parseLocation(location) {
   // 3. 부분 포함 검사 (Seoul, South Korea 같은 복합 지명)
   for (const [key, code] of Object.entries(COUNTRY_MAP)) {
     if (normalized.includes(key) && !found.has(code)) {
-      found.set(code, 0.88);
+      remember(code, 0.88, `location contains country keyword ${quoteValue(key)}`);
     }
   }
   for (const [key, code] of Object.entries(CITY_MAP)) {
     if (normalized.includes(key) && !found.has(code)) {
-      found.set(code, 0.83);
+      remember(code, 0.83, `location contains city keyword ${quoteValue(key)}`);
     }
   }
 
-  return [...found.entries()].map(([country, confidence]) => ({
-    country, confidence, source: 'location'
-  }));
+  return [...found.entries()].map(([country, details]) =>
+    createSignal(country, details.confidence, 'location', details.reason)
+  );
 }
 
 function analyzeBlogUrl(blog) {
@@ -385,7 +406,14 @@ function analyzeBlogUrl(blog) {
     // 알려진 플랫폼
     for (const [platform, code] of Object.entries(PLATFORM_MAP)) {
       if (hostname.endsWith(platform)) {
-        return [{ country: code, confidence: 0.85, source: 'blog_platform' }];
+        return [
+          createSignal(
+            code,
+            0.85,
+            'blog_platform',
+            `blog URL uses regional platform ${quoteValue(platform)}`
+          ),
+        ];
       }
     }
 
@@ -393,7 +421,14 @@ function analyzeBlogUrl(blog) {
     const sortedTlds = Object.keys(TLD_MAP).sort((a, b) => b.length - a.length);
     for (const tld of sortedTlds) {
       if (hostname.endsWith(tld)) {
-        return [{ country: TLD_MAP[tld], confidence: 0.80, source: 'blog_tld' }];
+        return [
+          createSignal(
+            TLD_MAP[tld],
+            0.80,
+            'blog_tld',
+            `blog URL ends with country TLD ${quoteValue(tld)}`
+          ),
+        ];
       }
     }
   } catch {
@@ -407,24 +442,31 @@ function analyzeCompany(company) {
   const normalized = company.toLowerCase().replace(/[@\s]/g, '');
   for (const [name, code] of Object.entries(COMPANY_MAP)) {
     if (normalized.includes(name)) {
-      return [{ country: code, confidence: 0.70, source: 'company' }];
+      return [
+        createSignal(
+          code,
+          0.70,
+          'company',
+          `company field includes ${quoteValue(name)}`
+        ),
+      ];
     }
   }
   return [];
 }
 
-function analyzeCharset(text) {
+function analyzeCharset(text, contextLabel = 'text') {
   if (!text) return [];
   const signals = [];
 
   // 한글 (한국어) — 매우 확실
   if (/[\uAC00-\uD7AF\u1100-\u11FF\u3130-\u318F]/.test(text)) {
-    signals.push({ country: 'KR', confidence: 0.95, source: 'charset_hangul' });
+    signals.push(createSignal('KR', 0.95, 'charset_hangul', `${contextLabel} contains Hangul`));
   }
 
   // 히라가나/가타카나 (일본어) — 매우 확실
   if (/[\u3040-\u309F\u30A0-\u30FF]/.test(text)) {
-    signals.push({ country: 'JP', confidence: 0.95, source: 'charset_kana' });
+    signals.push(createSignal('JP', 0.95, 'charset_kana', `${contextLabel} contains Kana`));
   }
 
   // CJK 한자만 있고 한글/가나 없을 때 → 중국어 가능성
@@ -432,32 +474,32 @@ function analyzeCharset(text) {
   const hasKorean = signals.some(s => s.country === 'KR');
   const hasJapanese = signals.some(s => s.country === 'JP');
   if (hasCJK && !hasKorean && !hasJapanese) {
-    signals.push({ country: 'CN', confidence: 0.70, source: 'charset_cjk' });
+    signals.push(createSignal('CN', 0.70, 'charset_cjk', `${contextLabel} contains CJK ideographs`));
   }
 
   // 키릴 문자 (러시아/동유럽)
   if (/[\u0400-\u04FF]/.test(text)) {
-    signals.push({ country: 'RU', confidence: 0.75, source: 'charset_cyrillic' });
+    signals.push(createSignal('RU', 0.75, 'charset_cyrillic', `${contextLabel} contains Cyrillic`));
   }
 
   // 데바나가리 (힌디/인도어)
   if (/[\u0900-\u097F]/.test(text)) {
-    signals.push({ country: 'IN', confidence: 0.90, source: 'charset_devanagari' });
+    signals.push(createSignal('IN', 0.90, 'charset_devanagari', `${contextLabel} contains Devanagari`));
   }
 
   // 태국 문자
   if (/[\u0E00-\u0E7F]/.test(text)) {
-    signals.push({ country: 'TH', confidence: 0.95, source: 'charset_thai' });
+    signals.push(createSignal('TH', 0.95, 'charset_thai', `${contextLabel} contains Thai script`));
   }
 
   // 히브리 문자
   if (/[\u0590-\u05FF]/.test(text)) {
-    signals.push({ country: 'IL', confidence: 0.85, source: 'charset_hebrew' });
+    signals.push(createSignal('IL', 0.85, 'charset_hebrew', `${contextLabel} contains Hebrew`));
   }
 
   // 아랍 문자
   if (/[\u0600-\u06FF]/.test(text)) {
-    signals.push({ country: 'AE', confidence: 0.60, source: 'charset_arabic' });
+    signals.push(createSignal('AE', 0.60, 'charset_arabic', `${contextLabel} contains Arabic script`));
   }
 
   return signals;
@@ -471,7 +513,7 @@ function analyzeTextLanguage(texts) {
   const signals = [];
 
   // 문자셋 기반 분석으로 대부분 커버
-  const charsetSignals = analyzeCharset(combined);
+  const charsetSignals = analyzeCharset(combined, 'bio / README / recent commits');
   signals.push(...charsetSignals);
 
   // 라틴 문자로만 이루어진 텍스트는 국가 특정 어려움
@@ -493,7 +535,7 @@ function analyzeTextLanguage(texts) {
 
 function aggregateSignals(signals) {
   if (signals.length === 0) {
-    return { country: 'Unknown', confidence: 0, sources: [] };
+    return { country: 'Unknown', confidence: 0, sources: [], reasons: [] };
   }
 
   const scores = {};
@@ -506,10 +548,25 @@ function aggregateSignals(signals) {
   const totalScore = Object.values(scores).reduce((a, b) => a + b, 0);
   const normalizedConfidence = topScore / totalScore;
 
+  const reasons = signals
+    .filter(signal => signal.country === topCountry)
+    .sort((a, b) => b.confidence - a.confidence)
+    .reduce((items, signal) => {
+      if (!items.some(item => item.text === signal.reason)) {
+        items.push({
+          source: signal.source,
+          confidence: signal.confidence,
+          text: signal.reason,
+        });
+      }
+      return items;
+    }, []);
+
   return {
     country: topCountry,
     confidence: Math.min(normalizedConfidence, 1.0),
     sources: signals.map(s => s.source),
+    reasons,
   };
 }
 
@@ -531,7 +588,7 @@ export function detectCountry(userData) {
 
   // Stage 4: 이름 + bio 문자셋 분석
   const nameAndBio = [userData.name, userData.bio].filter(Boolean).join(' ');
-  signals.push(...analyzeCharset(nameAndBio));
+  signals.push(...analyzeCharset(nameAndBio, 'name / bio'));
 
   // Stage 5: 커밋 메시지 + bio + README 언어 분석
   const texts = [


### PR DESCRIPTION
## What changed
- Added reason data to the country detection result so we can explain why a country was chosen
- Show the reason in the repository badge on hover with a small expandable card
- Updated the hover card styles to match GitHub theme colors in both light and dark mode
- Refetched old cached entries that do not include reason data

## Why
- The badge previously showed only the detected country and confidence, which made the result hard to trust
- This change makes the detection more transparent and easier to understand at a glance

## Validation
- Ran `node --check extension/country_detector.js`
- Ran `node --check extension/background.js`
- Ran `node --check extension/content.js`
